### PR TITLE
java 1.6+ compilation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# sbt specific
+.cache
+.history
+.lib/
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<java.version>1.6</java.version>
 	</properties>
 
 	<dependencies>
@@ -128,6 +129,15 @@
 		<outputDirectory>target/scala/classes</outputDirectory>
 		<testOutputDirectory>target/scala/test-classes</testOutputDirectory>
 		<plugins>
+                        <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-compiler-plugin</artifactId>
+                                <version>3.2</version>
+                                <configuration>
+                                        <source>${java.version}</source>
+                                        <target>${java.version}</target>
+                                </configuration>
+                        </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
Java source level was not specified, so you've probably got errors like this:

    [ERROR] (use -source 5 or higher to enable generics)
    [ERROR] git/SparkOnHBase/src/main/java/com/cloudera/spark/hbase/example/JavaHBaseMapGetPutExample.java:[38,8] error: generics are not supported in -source 1.3

Added maven-compiler-plugin to pom.xml with explicit java source version (1.6 - seems to be most common now, supported by most Hadoop distributions).